### PR TITLE
Add biolink_model_pydantic to deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,8 @@ setup(
         'pandas',
         'networkx',
         'multi-indexer',
-        'koza'
-
+        'koza',
+        'biolink_model_pydantic'
     ],
     extras_require=extras,
 )


### PR DESCRIPTION
Koza shifted biolink_model_pydantic to a dev dependency, but we still use it here.